### PR TITLE
Add basic restrictions

### DIFF
--- a/api/channel-is-forbidden.js
+++ b/api/channel-is-forbidden.js
@@ -1,0 +1,6 @@
+const { default: fetch } = require("node-fetch")
+
+module.exports = async function(channelID) {
+  const forbiddenChannels = ['C74HZS5A5', 'C75M7C0SY', 'C01504DCLVD', 'C0M8PUPU6'] // lobby, welcome scrapbook, ship
+  return !forbiddenChannels.includes(channelID)
+}

--- a/api/endpoints/slack/slash-z.js
+++ b/api/endpoints/slack/slash-z.js
@@ -1,9 +1,40 @@
 const { default: fetch } = require("node-fetch")
 const AirBridge = require("../../airbridge")
 const isPublicSlackChannel = require("../../is-public-slack-channel")
+const userIsRestricted = require("../../user-is-restricted")
+const channelIsForbidden = require("../../channel-is-forbidden")
 const openZoomMeeting = require('../../open-zoom-meeting')
+const transcript = require('../../transcript')
 
 module.exports = async (req, res) => {
+  if (userIsRestricted(req.body.channel_id)) {
+    return fetch(req.body.response_url, {
+      method: 'post',
+      headers: {
+        'Authorization': `Bearer ${process.env.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        response_type: 'ephemeral',
+        text: transcript('errors.userIsRestricted')
+      })
+    })
+  }
+
+  if (channelIsForbidden(req.body.user_id)) {
+    return fetch(req.body.response_url, {
+      method: 'post',
+      headers: {
+        'Authorization': `Bearer ${process.env.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        response_type: 'ephemeral',
+        text: transcript('errors.channelIsForbidden')
+      })
+    })
+  }
+
   const loadingSlackPost = await fetch(req.body.response_url, {
     method: 'post',
     headers: {

--- a/api/user-is-restricted.js
+++ b/api/user-is-restricted.js
@@ -1,0 +1,6 @@
+const { default: fetch } = require("node-fetch")
+
+module.exports = async function(userID) {
+  const userInfo = await fetch(`https://slack.com/api/users.info?token=${process.env.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN}&user=${userID}`).then(r => r.json())
+  return userInfo.user.is_restricted
+}

--- a/lib/transcript.yml
+++ b/lib/transcript.yml
@@ -211,4 +211,6 @@ publicChannelFlavor:
     - "Tea parties :tea:" # https://hackclub.slack.com/archives/C0158NY6QEN/p1615328859017200?thread_ts=1615328097.016700&cid=C0158NY6QEN
   C0146U2KVUK: # rishi's personal channel
     - ":ferrisbongo:" # https://hackclub.slack.com/archives/C0158NY6QEN/p1615340301017400?thread_ts=1615328097.016700&cid=C0158NY6QEN
-  
+errors:
+  userIsRestricted: 'Sorry, you need to be a full member of Hack Club in order to run this command.'
+  channelIsForbidden: 'Sorry, you can`'t start a meeting in this channel.'


### PR DESCRIPTION
We're getting a lot of multi-channel guests starting Zoom meetings in `#lobby`. We've also previously had people start Zoom meetings in threaded channels like `#scrapbook` and `#ship`. This prevents both of those things from happening.