### PR TITLE
Use a mention instead of user_name

### DIFF
--- a/api/endpoints/slack/slash-z.js
+++ b/api/endpoints/slack/slash-z.js
@@ -84,7 +84,7 @@ module.exports = async (req, res) => {
     date_start: Math.floor(Date.now() / 1000), // Slack works in seconds, Date.now gives ms
     desktop_app_join_url: `zoommtg://zoom.us/join?confno=${meeting.id}&zc=0&pwd=${meeting.encrypted_password}`,
     external_display_id: meeting.id,
-    title: `Zoom Pro meeting started by ${req.body.user_name}`
+    title: `Zoom Pro meeting started by <@${req.body.user_id}>`
   }
 
   const slackCallResult = await fetch('https://slack.com/api/calls.add', {


### PR DESCRIPTION
IIRC `user_name` is deprecated and sometimes sends the email address or some other identifiable string. This uses a mention (`<@${user_id}>`) instead of the name as it has unexpected behaviors.

This is a draft because it has not been tested.