### PR TITLE
Add continue with message to Google Calendar auth screen

### DIFF
--- a/public/auth-start.html
+++ b/public/auth-start.html
@@ -190,13 +190,28 @@
       .addressee {
         font-size: 2rem;
       }
+      .continue-header {
+        color: white;
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      }
+      .sound-on, .sound-off {
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        padding: 4px;
+        font-weight: 500;
+      }
+      .sound-choice {
+        padding: 10px;
+      }
     </style>
   </head>
 
   <body>
     <div class="sound-choice">
-      <button class="sound-on">Background music</button>
-      <button class="sound-off">No sound</button>
+      <center> <!-- Only using the <center> tag because I don't want to mess with absolute positioning -->
+        <h2 class="continue-header">Continue with...</h2>
+        <button class="sound-on">Background music</button>
+        <button class="sound-off">No sound</button>
+      </center>
     </div>
     <canvas class="canvas hidden"></canvas>
     <div class="message hidden">


### PR DESCRIPTION
Adds a continue with (music, no sound) header to the Google Calendar auth screen in case people get confused.

![Continue with](https://yodacode.xyz/F931d4b959e.png)