### PR TITLE
Add recording timestamps (#53)

### DIFF
--- a/api/slack-app-home-opened.js
+++ b/api/slack-app-home-opened.js
@@ -57,7 +57,12 @@ const publishHomePage = async ({user, results}) => {
       password: c.settings.password,
       url: c.share_url,
       meetingID: c.id,
-      timestamp: `${new Date(c.start_time).toLocaleString('en-US', { timeZone: user.tz })}`,
+      timestamp: `${(() => {
+        const timestamp = Math.floor(new Date(c.start_time).valueOf() / 1000);
+        const fallback = new Date(c.start_time).toLocaleString('en-US', { timeZone: user.tz });
+        const slackTimeString = `<!date^${timestamp}^Started {date_pretty} at {time}|${fallback}>`;
+        return slackTimeString;
+      })()}`,
       duration: Math.max(c.duration, 1) // '0 minute call' -> '1 minute call'
     }))
     blocks.push(transcript('appHome.recordedMeetings.completedHeader', { count: completedRecordings.length }))

--- a/api/slack-app-home-opened.js
+++ b/api/slack-app-home-opened.js
@@ -57,6 +57,7 @@ const publishHomePage = async ({user, results}) => {
       password: c.settings.password,
       url: c.share_url,
       meetingID: c.id,
+      timestamp: `${new Date(c.start_time).toLocaleString()}`, // fix date string formatting before merging
       duration: Math.max(c.duration, 1) // '0 minute call' -> '1 minute call'
     }))
     blocks.push(transcript('appHome.recordedMeetings.completedHeader', { count: completedRecordings.length }))

--- a/api/slack-app-home-opened.js
+++ b/api/slack-app-home-opened.js
@@ -57,7 +57,7 @@ const publishHomePage = async ({user, results}) => {
       password: c.settings.password,
       url: c.share_url,
       meetingID: c.id,
-      timestamp: `${new Date(c.start_time).toLocaleString()}`, // fix date string formatting before merging
+      timestamp: `${new Date(c.start_time).toLocaleString('en-US', { timeZone: 'UTC' })} UTC`,
       duration: Math.max(c.duration, 1) // '0 minute call' -> '1 minute call'
     }))
     blocks.push(transcript('appHome.recordedMeetings.completedHeader', { count: completedRecordings.length }))

--- a/api/slack-app-home-opened.js
+++ b/api/slack-app-home-opened.js
@@ -57,7 +57,7 @@ const publishHomePage = async ({user, results}) => {
       password: c.settings.password,
       url: c.share_url,
       meetingID: c.id,
-      timestamp: `${new Date(c.start_time).toLocaleString('en-US', { timeZone: 'UTC' })} UTC`,
+      timestamp: `${new Date(c.start_time).toLocaleString('en-US', { timeZone: user.tz })}`,
       duration: Math.max(c.duration, 1) // '0 minute call' -> '1 minute call'
     }))
     blocks.push(transcript('appHome.recordedMeetings.completedHeader', { count: completedRecordings.length }))

--- a/lib/transcript.yml
+++ b/lib/transcript.yml
@@ -170,7 +170,7 @@ appHome:
       text:
         type: mrkdwn
         text: |
-          - <${this.url}|Meeting ${this.meetingID} _(${this.duration} minutes long)_> (password *${this.password}*)
+          - <${this.url}|Meeting ${this.meetingID} _(${this.duration} minutes long)_> (password *${this.password}*) - ${this.timestamp}
     completedFooter:
       type: section
       text:


### PR DESCRIPTION
Add recording timestmaps for #53.
- Adds meeting start time to the homepage recording list in the user's timezone
- Tested on `@slash-z-testing-alt` 