### PR TITLE
Check all falsy values for oauth error

### DIFF
--- a/api/endpoints/slack-auth.js
+++ b/api/endpoints/slack-auth.js
@@ -18,7 +18,7 @@ export default async (req, res) => {
     const slackData = await fetch(tokenUrl, {method: 'post'}).then(r => r.json())
     
     // Check if the authed user actually exists
-    if (slackData?.authed_user?.id === null) {
+    if (!slackData?.authed_user?.id) { // Instead of checking null, check any falsy value, such as undefined
       res.redirect('/auth-error.html')
       return
     }


### PR DESCRIPTION
Right now, you can join the meeting even if you provide an invalid OAuth code (or none at all) because the user (if any) would be `undefined`, not `null`. This fixes it to check any falsy value, `!slackData?.authed_user?.id`, requiring both the user to exist and the user to have an ID.