### PR TITLE
Fix #62

### DIFF
--- a/api/endpoints/zoom.js
+++ b/api/endpoints/zoom.js
@@ -16,7 +16,7 @@ export default async (req, res) => {
     // Let's lookup our webhook event to see if we already got this event.
     const zoomCallID = req.body.payload.object.id
 
-    const meeting = await Prisma.find('meeting', { where: { zoomID: zoomCallID.toString() } })
+    const meeting = await Prisma.find('meeting', { where: { zoomID: zoomCallID.toString() }, include: { schedulingLink: true } })
 
     const fields = {
       timestamp: new Date(req.body.event_ts),

--- a/manifest.yml
+++ b/manifest.yml
@@ -29,8 +29,8 @@ oauth_config:
       - chat:write
       - commands
       - users:read
-      - bookmarks:write
       - bookmarks:read
+      - bookmarks:write
 settings:
   event_subscriptions:
     request_url: https://slash-z.hackclub.com/api/endpoints/slack/events


### PR DESCRIPTION
Fixes #62 by asking Prisma for `schedulingLink`. Previously, it wasn't asking for the relational property.