### PR TITLE
Fix the pluralize function

### DIFF
--- a/api/transcript.js
+++ b/api/transcript.js
@@ -6,10 +6,10 @@ const pluralize = (word, count) => {
   // want to use this method? make sure to add your word to transcript.yml under 'plurals'
   if (count == 1) {
     // singular
-    return `${count} ${transcript('plurals.' + word)}`
+    return `${count} ${word}`
   } else {
     // plural or zero
-    return `${count} ${word}`
+    return `${count} ${transcript('plurals.' + word)}`
   }
 }
 


### PR DESCRIPTION
Previously, usage of plural words for subjects would be used when they were supposed to be singular, and vice versa