### PR TITLE
Skip slack auth for Hack Night

### DIFF
--- a/api/endpoints/schedule-link.js
+++ b/api/endpoints/schedule-link.js
@@ -1,4 +1,5 @@
 import findOrCreateMeeting from "../find-or-create-meeting.js"
+import { currentTimeHash } from "../time-hash.js"
 
 export default async (req, res) => {
   const { query } = req
@@ -11,18 +12,19 @@ export default async (req, res) => {
 
   try {
     
-    if (query.id === "1vu13b") { // Special case for Hack Night
+    if (query.id === "1vu13b" && query.key !== currentTimeHash()) { // Special case for Hack Night
       const state = { meetingID: query.id }
       const stateString = encodeURIComponent(Buffer.from(JSON.stringify(state), "utf8").toString("base64"))
       
       const redirectUrl = 'https://hack.af/z/slack-auth'
       // Redirect to Slack Auth specifying that it's /z
-      res.redirect(`https://slack.com/oauth/v2/authorize?response_type=code&redirect_uri=${encodeURIComponent(redirectUrl)}&user_scope=identify&client_id=2210535565.1711449950551&state=${stateString}`)
+      return res.redirect(`https://slack.com/oauth/v2/authorize?response_type=code&redirect_uri=${encodeURIComponent(redirectUrl)}&user_scope=identify&client_id=2210535565.1711449950551&state=${stateString}`)
+      // Return to prevent creating a meeting if it's not necessary
     }
     
     if (query.id === "5s7xrr") { 
       // Special case for George Hotz AMA, redirect to another Zoom link
-      res.redirect('https://hack.af/geohot-zoom')
+      return res.redirect('https://hack.af/geohot-zoom')
     }
     
     const airtableMeeting = await findOrCreateMeeting(query.id)

--- a/api/hack-night.js
+++ b/api/hack-night.js
@@ -1,19 +1,18 @@
 import fetch from "node-fetch";
+import { currentTimeHash } from "./time-hash.js";
 
-export async function fetchParticipantNumber () {
+export async function fetchBookmarkTitle () {
   const response = await fetch('https://slack.com/api/bookmarks.list?channel_id=C0JDWKJVA', {
     headers: {
       Authorization: `Bearer ${process.env.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN}`
     }
   });
   const json = await response.json();
-  // console.log(json);
   const { title } = json.bookmarks.filter(bookmark => bookmark.id === "Bk027L39LR9A")[0];
-  const number = +(title.split('').filter(char => !isNaN(char)).join('') || '0');
-  return number;
+  return title;
 }
 
-export async function setParticipantNumber (number) {
+export async function setBookmarkTitle (title) {
   const response = await fetch('https://slack.com/api/bookmarks.edit', {
     method: 'POST',
     headers: {
@@ -24,17 +23,25 @@ export async function setParticipantNumber (number) {
       bookmark_id: 'Bk027L39LR9A',
       channel_id: 'C0JDWKJVA',
       emoji: ':zoom:',
-      link: 'https://hack.af/night',
-      title: 'Join Hack Night! 👤 ' + number
+      link: 'https://hack.af/night?key=' + currentTimeHash(),
+      title
     })
   });
   const json = await response.json();
-  // console.log(json);
   return json;
 }
 
-export default async function hackNightStats (event, meeting, payload) {
+export async function fetchParticipantNumber () {
+  const title = await fetchBookmarkTitle();
+  const number = +(title.split('').filter(char => !isNaN(char)).join('') || '0');
+  return number;
+}
 
+export async function setParticipantNumber (number) {
+  return await setBookmarkTitle('Join Hack Night! 👤 ' + number);
+}
+
+export default async function hackNightStats (event, meeting, payload) {
   switch (event) {
     case 'meeting.ended':
       await setParticipantNumber(0);

--- a/api/time-hash.js
+++ b/api/time-hash.js
@@ -1,0 +1,5 @@
+import { createHash } from 'crypto';
+
+export function currentTimeHash () {
+    return createHash('sha256').update(new Date().getHours() + '' + (process.env.JOIN_URL_SALT ?? '')).digest('hex');
+}

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 import './env.js'
 import './jobs/index.js'
+import { setBookmarkTitle } from './api/hack-night.js'
 import transcript from './api/transcript.js'
 
 import express from 'express'
@@ -26,3 +27,7 @@ const port = process.env.PORT || 0
 const listener = app.listen(port, () => {
   console.log(transcript('startup', {port: listener.address().port}))
 })
+
+setInterval(() => {
+  setBookmarkTitle();
+}, 1000 * 60) // update the hack night bookmark every minute with the correct url


### PR DESCRIPTION
Sometimes joining Hack Night can be a bit of a pain, especially on mobile devices that aren't signed into Slack on Safari.

This PR adds a unique URL parameter updated every hour enabling one-click meeting joining. Navigating directly to [hack.af/night](https://hack.af/night) will still require Slack auth, but using the channel bookmark will be more convenient for mobile users.



Tasks:
 - [x] Set the `JOIN_URL_SALT` environment variable on Heroku