### PR TITLE
Change hard-coded slack client ids to use env vars

### DIFF
--- a/api/endpoints/new-schedule-link.js
+++ b/api/endpoints/new-schedule-link.js
@@ -14,7 +14,7 @@ export default async (req, res) => {
     console.log({state})
     const stateString = encodeURIComponent(Buffer.from(JSON.stringify(state), "utf8").toString("base64"))
     
-    const authUrl = `https://js-slash-z.hackclub.com/auth-start.html?response_type=code&redirect_uri=${encodeURIComponent(redirectUrl)}&user_scope=identify&client_id=2210535565.1711449950551&state=${stateString}`
+    const authUrl = `https://js-slash-z.hackclub.com/auth-start.html?response_type=code&redirect_uri=${encodeURIComponent(redirectUrl)}&user_scope=identify&client_id=${process.env.SLACK_CLIENT_ID}&state=${stateString}`
     return res.json({
       error: 'AUTH',
       authUrl

--- a/api/endpoints/schedule-link.js
+++ b/api/endpoints/schedule-link.js
@@ -18,7 +18,7 @@ export default async (req, res) => {
       
       const redirectUrl = 'https://hack.af/z/slack-auth'
       // Redirect to Slack Auth specifying that it's /z
-      return res.redirect(`https://slack.com/oauth/v2/authorize?response_type=code&redirect_uri=${encodeURIComponent(redirectUrl)}&user_scope=identify&client_id=2210535565.1711449950551&state=${stateString}`)
+      return res.redirect(`https://slack.com/oauth/v2/authorize?response_type=code&redirect_uri=${encodeURIComponent(redirectUrl)}&user_scope=identify&client_id=${process.env.SLACK_CLIENT_ID}&state=${stateString}`)
       // Return to prevent creating a meeting if it's not necessary
     }
     


### PR DESCRIPTION
This afternoon I set up the full slash-z debugging environment.  There are two components (on our side) of this:

1. A clone of the [gcal integration](https://github.com/hackclub/slash-z-google-calendar) (clasp/Google appscript):
<img width="200" alt="Screenshot 2023-03-18 at 7 12 02 PM" src="https://user-images.githubusercontent.com/43505167/226145831-3b58886a-0dff-493b-a236-5ffbd973ce8a.png">

2. [/z](https://github.com/hackclub/slash-z) running locally and exposed remotely via ngrok.
<img width="200" alt="Screenshot 2023-03-18 at 7 53 34 PM" src="https://user-images.githubusercontent.com/43505167/226145999-c4e91aaf-351d-4d80-96f9-677bfa0c3a76.png">
<img width="200" alt="Screenshot 2023-03-18 at 7 13 39 PM" src="https://user-images.githubusercontent.com/43505167/226145851-a7ac2e8a-9a8f-4f40-a5c0-655ad0156c67.png">

With this setup, I was able to carefully step with a debugger through the entirety of the flow.  I had to modify many URLs on both the gcal and slash-z side to configure it correctly.  I had some additional observability on script.google.com side of things as such:
<img width="200" alt="Screenshot 2023-03-18 at 7 55 47 PM" src="https://user-images.githubusercontent.com/43505167/226146112-7412fba6-c8de-43de-89a6-856743f829b6.png">

After modifying a lot of URLs on the slash-z service side, **I was able to see the entirety of the gcal integration work without any changes to the logic** - only URLs.

One of the very notable changes I had to make on the slash-z service side to get this working were two lines (see this PR) that had hard-coded client-id's that were not grabbed from environment variables.  They should, but do not match the configuration currently set in slash-z, and you can notice that these are localized to code specifically dealing with new scheduling links - I believe this could explain perfectly the Slack auth errors we are seeing in gcal integration and hack.af/night for unauthenticated users only.
<img width="200" alt="Screenshot 2023-03-18 at 5 14 49 PM" src="https://user-images.githubusercontent.com/43505167/226146480-7a9c1e41-14e5-471e-98a4-a30ab3eed89c.png">
