### PR TITLE
fixes slack call integration when leaving

### DIFF
--- a/api/update-slack-call-participant-list.js
+++ b/api/update-slack-call-participant-list.js
@@ -21,14 +21,9 @@ export default async (addOrRemove, callID, zoomParticipant) => {
   // ex. someone@gmail.com (without a hack club zoom license) joins, leaves, & rejoins the call
   // their first participant_join event has user ID 16778240, & their second participant_join event has user ID 16790528
   user['external_id'] = name || email || zoomID
+  user['avatar_url'] = await userToAvatar({name, email})
+  user['display_name'] = name
 
-  // Slack's calls.participants.remove works just as well if we only provide an
-  // external_id, so let's skip getting their other details to speed up the
-  // request
-  if (addOrRemove == 'add') {
-    user['avatar_url'] = await userToAvatar({name, email})
-    user['display_name'] = name
-  }
   const result = await fetch(`https://slack.com/api/calls.participants.${addOrRemove}`, {
     method: 'post',
     headers: {


### PR DESCRIPTION
The commentary stating it "works just as well" appears to not be the case anymore.  Before applying this change, I was able to reproduce the following bug:

1) Create a new zoom using /z in slack.
2) Join the zoom call
3) Observe the calls participant list in Slack update with your user.
4) Leave the zoom call
Expected result: Participant list in Slack should update, removing your user
Actual result: Participant list in Slack does not change