### PR TITLE
Fixes typo that causes reference error

### DIFF
--- a/api/endpoints/zoom.js
+++ b/api/endpoints/zoom.js
@@ -40,7 +40,7 @@ export default async (req, res) => {
 
     switch (req.body.event) {
       case 'meeting.ended':
-        await Prisma.create('customLogs', { text: 'zoom_end_meeting_webhook', zoomCallId: zoomCallId || "undefined" })
+        await Prisma.create('customLogs', { text: 'zoom_end_meeting_webhook', zoomCallId: zoomCallID || "undefined" })
         console.log('Attempting to close call w/ ID of', zoomCallID)
         return await closeZoomCall(zoomCallID, false, true)
         break


### PR DESCRIPTION
This caused not only the logs not to be created, but also we wouldn't call closeZoomCall(...) after meetings end...