### PR TITLE
Specify utf8 charset in slack.calls user updates

### DIFF
--- a/api/update-slack-call-participant-list.js
+++ b/api/update-slack-call-participant-list.js
@@ -28,7 +28,7 @@ export default async (addOrRemove, callID, zoomParticipant) => {
     method: 'post',
     headers: {
       'Authorization': `Bearer ${process.env.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN}`,
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json; charset=utf-8'
     },
     body: JSON.stringify({
       id: callID,


### PR DESCRIPTION
Prior to this change, warnings would be returned from the calls.participants.add/remove APIs as such:

```
2023-07-03T17:43:40.568418+00:00 app[web.1]: warning: 'missing_charset',
2023-07-03T17:43:40.568418+00:00 app[web.1]: response_metadata: { warnings: [ 'missing_charset' ] }

```