### PR TITLE
fix: convert windows path to match file:// scheme && remove trailing url

### DIFF
--- a/api/transcript.js
+++ b/api/transcript.js
@@ -23,7 +23,7 @@ const loadTranscript = () => {
 
   try {
     const doc = yaml.load(
-      readFileSync(path.join(__dirname, '..', 'lib', 'transcript.yml'), 'utf8')
+      readFileSync(path.join(__dirname, '..', 'lib', 'transcript.yml').slice(1), 'utf8')
     )
     return doc
   } catch (e) {

--- a/routes.js
+++ b/routes.js
@@ -1,6 +1,6 @@
 import { resolve, relative, extname, basename, dirname } from 'path'
 import { readdir } from 'fs/promises'
-
+import { pathToFileURL } from "url";
 import recordError from './api/record-error.js'
 
 async function getFiles(dir) {
@@ -35,7 +35,7 @@ export default async (app) => {
         routePath = `${routePath}/${basename(file, extname(file))}`
       }
 
-      const route = (await import(file)).default // just to test we can load the file
+      const route = (await import(pathToFileURL(file))).default // just to test we can load the file
 
       app.all('/' + routePath, async (req, res) => {
         try {


### PR DESCRIPTION
Should fix #105 

- Removes the `/` before the full path of transcript.yml
- Converts windows paths to paths matching matching the `file://` scheme