### PR TITLE
remove unecessary where clause

### DIFF
--- a/api/open-zoom-meeting.js
+++ b/api/open-zoom-meeting.js
@@ -58,7 +58,7 @@ export default async ({ creatorSlackID, isHackNight } = {}) => {
     // get the user's zoom id
     const hostZoom = await zoom.get({ path: `users/${host.email}` });
     host = await Prisma.patch("host", host.id, {
-      where: { zoomID: hostZoom.id },
+      zoomID: hostZoom.id
     });
 
     // (max@maxwofford.com) This looks super redundant. Why are we also setting


### PR DESCRIPTION
resolves #113 
- remove unecessary where clause
- this change will ensure that when we add a new host, /z will automatically populate a new ZoomID so the host is usable