### PR TITLE
trace slack meetings and filter meetings within certain time range

### DIFF
--- a/scripts/zstory.py
+++ b/scripts/zstory.py
@@ -115,7 +115,7 @@ def dissect_scheduled_meeting(cursor: Cursor, meetid: str, start, end):
         cursor.execute(queries.get("end"), (scheduling_link_id, datetime.fromtimestamp(start), datetime.fromtimestamp(end)))
     elif start and end is None:
         cursor.execute(queries.get("start"), (scheduling_link_id, datetime.fromtimestamp(start)))
-    else: cursor.execute(queries.get("normal"), (scheduling_link_id))
+    else: cursor.execute(queries.get("normal"), (scheduling_link_id, ))
 
     meetings = cursor.fetchall()
 

--- a/scripts/zstory.py
+++ b/scripts/zstory.py
@@ -37,7 +37,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("-s", "--sched")
 parser.add_argument("-z", "--zoom")
 parser.add_argument("--start", type=int)
-parser.add_argument("--end", type=int, default=1)
+parser.add_argument("--end", type=int)
 
 # parse the arguments!
 args = parser.parse_args()
@@ -69,14 +69,14 @@ def trace_events(cursor: Cursor, meetingId: str):
         
         print(f"{(time - start_time).seconds:5}s later | {(participant['user_name'] if participant else ''):15} | 🫡{event_type:6}")
 
-def filter_by_date(cursor: Cursor, start: int, end: int):
+def filter_by_date(cursor: Cursor, start: int, end: int | None):
     query_no_end = 'SELECT ("zoomID", "startedAt", "endedAt") FROM "Meeting" WHERE "startedAt">=%s ORDER BY "startedAt" ASC' 
     query_with_end = 'SELECT ("zoomID", "startedAt", "endedAt") FROM "Meeting" WHERE "startedAt">=%s AND "startedAt"<=%s ORDER BY "startedAt" ASC'
 
-    if end == 1:
-        cursor.execute(query_no_end, (datetime.fromtimestamp(start),))
-    else:
+    if end is not None:
         cursor.execute(query_with_end, (datetime.fromtimestamp(start), datetime.fromtimestamp(end)))
+    else:
+        cursor.execute(query_no_end, (datetime.fromtimestamp(start),))
 
     meetings = cursor.fetchall()
     print(meetings)
@@ -96,7 +96,7 @@ with psycopg.connect(config("DATABASE_URL")) as conn:
     # open cursor to perform database operations
     with conn.cursor() as cursor:
 
-        if args.start and args.end:
+        if args.start:
             filter_by_date(cursor, args.start, args.end)
             quit()
 

--- a/scripts/zstory.py
+++ b/scripts/zstory.py
@@ -87,7 +87,7 @@ def filter_by_date(cursor: Cursor, start: int, end: int):
         
         if meeting[2] is not None:
             time_elapsed = datetime.fromisoformat(meeting[2]) - datetime.fromisoformat(meeting[1])
-            print(f"zoomID: {meeting[0]} | started {meeting[1]} ended {time_elapsed.seconds if time_elapsed else 'Ongoing'}s later ") 
+            print(f"zoomID: {meeting[0]} | started {meeting[1]} ended {time_elapsed.seconds}s later ") 
         else: print(f"zoomID: {meeting[0]} | started {meeting[1]} Ongoing...") 
 
 


### PR DESCRIPTION
tackling #125 

- now trace a scheduled meeting with `zstory.py dissect <schedule-name>`
- get only scheduled meetings that occurred within a time range `zstory.py dissect <schedule-name> --start <start-time> --end <end-time>` (`<end-time>` is optional and will fallback to tracing all meetings >= `<start-time>`)
- now trace a slack meeting with `zstory.py dissect <meeding-it> -z`
- now trace a meeting within a time range `zstory.py dissect --start <start-time> --end <end-time>` (`<end-time>` is optional and will fallback to tracing all meetings >= `<start-time>`)