### PR TITLE
reactivate close-stale-calls job

### DIFF
--- a/jobs/index.js
+++ b/jobs/index.js
@@ -11,14 +11,14 @@ import './migrate-airtable-to-prisma.js'
 // we'll queue it up for a couple minutes later in case we have multiple rebuilds in a row
 if (isProd) {
   console.log('Queueing jobs...')
-  setTimeout(cleanupAirtableRecords, 1000 * 60 * 10) // after 10 minutes in milliseconds
+  // setTimeout(cleanupAirtableRecords, 1000 * 60 * 10) // after 10 minutes in milliseconds
 
-  // setTimeout(() => {
-  //   setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
-  // }, 1000 * 60) // after 1 minute in milliseconds
+  setTimeout(() => {
+  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  }, 1000 * 60) // after 1 minute in milliseconds
 } else {
-  // closeStaleCalls()
-  // setTimeout(() => {
-  //   setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
-  // }, 1000 * 60) // after 1 minute in milliseconds
+  closeStaleCalls()
+  setTimeout(() => {
+  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  }, 1000 * 60) // after 1 minute in milliseconds
 }


### PR DESCRIPTION
should help #141 
users can start as many calls as our license number permit now from Slack without necessarily joining them and starting a call from Slack marks a license as utilized.

This results in grafana showing high usage on the dashboard -- users will potentially see "out of hosts" error 

This can be avoided if we close stale calls 