### PR TITLE
don't automatically close a zoom call

### DIFF
--- a/api/close-zoom-call.js
+++ b/api/close-zoom-call.js
@@ -8,10 +8,9 @@ import fetch from "node-fetch";
 * @function
 * @param {string} zoomID - The zoom call id
 * @param {boolean} forceClose - force close the zoom call. Defaults to false
-* @param {boolean} fromWebhook - The record ID 
 * @returns {Promise<Object>}
 */
-export default async (zoomID, forceClose = false, fromWebhook = false) => {
+export default async (zoomID, forceClose = false) => {
 
   const meeting = await Prisma.find("meeting", {
     where: { zoomID },

--- a/api/endpoints/zoom.js
+++ b/api/endpoints/zoom.js
@@ -43,7 +43,7 @@ export default async (req, res) => {
       case 'meeting.ended':
         await Prisma.create('customLogs', { text: 'zoom_end_meeting_webhook', zoomCallId: zoomCallID || "undefined" })
         console.log('Attempting to close call w/ ID of', zoomCallID)
-        return await closeZoomCall(zoomCallID, false, true)
+        return await closeZoomCall(zoomCallID, false)
         break
       case 'meeting.participant_joined':
         console.log('triggered!')

--- a/jobs/index.js
+++ b/jobs/index.js
@@ -13,12 +13,12 @@ if (isProd) {
   console.log('Queueing jobs...')
   setTimeout(cleanupAirtableRecords, 1000 * 60 * 10) // after 10 minutes in milliseconds
 
-  // setTimeout(() => {
-  //   setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
-  // }, 1000 * 60) // after 1 minute in milliseconds
+  setTimeout(() => {
+  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  }, 1000 * 60) // after 1 minute in milliseconds
 } else {
-  // closeStaleCalls()
-  // setTimeout(() => {
-  //   setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
-  // }, 1000 * 60) // after 1 minute in milliseconds
+  closeStaleCalls()
+  setTimeout(() => {
+  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  }, 1000 * 60) // after 1 minute in milliseconds
 }

--- a/jobs/index.js
+++ b/jobs/index.js
@@ -11,14 +11,14 @@ import './migrate-airtable-to-prisma.js'
 // we'll queue it up for a couple minutes later in case we have multiple rebuilds in a row
 if (isProd) {
   console.log('Queueing jobs...')
-  // setTimeout(cleanupAirtableRecords, 1000 * 60 * 10) // after 10 minutes in milliseconds
+  setTimeout(cleanupAirtableRecords, 1000 * 60 * 10) // after 10 minutes in milliseconds
 
-  setTimeout(() => {
-  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
-  }, 1000 * 60) // after 1 minute in milliseconds
+  // setTimeout(() => {
+  //   setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  // }, 1000 * 60) // after 1 minute in milliseconds
 } else {
-  closeStaleCalls()
-  setTimeout(() => {
-  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
-  }, 1000 * 60) // after 1 minute in milliseconds
+  // closeStaleCalls()
+  // setTimeout(() => {
+  //   setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  // }, 1000 * 60) // after 1 minute in milliseconds
 }


### PR DESCRIPTION
this change should entirely remove the situation where calls are abruptly closed
and leave it up to deleteMeeting to invalidate the call when there are no participants left in it