### PR TITLE
Reducing frequency of metrics checks to avoid rate limitation

### DIFF
--- a/api/close-zoom-call.js
+++ b/api/close-zoom-call.js
@@ -32,6 +32,9 @@ export default async (zoomID, forceClose = false) => {
     if (response.http_code == 400) {
       return metrics.increment("delete_meeting.warning", 1);
     } else if (response.http_code == 404) {
+      // Report this also as a general error...
+      metrics.increment("error.delete_meeting");
+
       return metrics.increment("delete_meeting.error", 1);
     }
     return metrics.increment("delete_meeting.success", 1);
@@ -43,6 +46,7 @@ export default async (zoomID, forceClose = false) => {
   });
 
   if(!zoomMetrics) {
+    metrics.increment("error.metrics_not_defined", 1);
     await Prisma.create('customLogs', { text: `metrics_not_defined`, zoomCallId: meeting.zoomID })
     return null;
   }

--- a/jobs/index.js
+++ b/jobs/index.js
@@ -14,11 +14,11 @@ if (isProd) {
   setTimeout(cleanupAirtableRecords, 1000 * 60 * 10) // after 10 minutes in milliseconds
 
   setTimeout(() => {
-  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  setInterval(closeStaleCalls, 1000 * 120) // every 2 minutes
   }, 1000 * 60) // after 1 minute in milliseconds
 } else {
   closeStaleCalls()
   setTimeout(() => {
-  setInterval(closeStaleCalls, 1000 * 15) // every 15 seconds
+  setInterval(closeStaleCalls, 1000 * 120) // every 2 minutes
   }, 1000 * 60) // after 1 minute in milliseconds
 }


### PR DESCRIPTION
There is evidence of rate limitation occurring in Slash-Z, and as a result there is a discrepency between Slash-Z's bookkeeping and what Zoom reports as true on their dashboards.  The fact that we see basically zero 200's for metrics as of 8:15am makes me believe we have run into a daily rate limitation cap.
<img width="512" alt="Screenshot 2023-09-06 at 4 47 34 PM" src="https://github.com/hackclub/slash-z/assets/43505167/9aab99f6-4be3-4d53-9d45-69f6f557edf1">

The code relating to the rate limited endpoint is, I believe, the following:
<img width="512" alt="Screenshot 2023-09-06 at 4 29 46 PM" src="https://github.com/hackclub/slash-z/assets/43505167/a71df68d-278c-47b9-847c-225d94d9d6f6">
<br>
Per the Zoom API documentation, the metrics / participants endpoint is classified as "Heavy".
<img width="512" alt="Screenshot 2023-09-06 at 4 32 23 PM" src="https://github.com/hackclub/slash-z/assets/43505167/43f0f12e-5179-47d2-b707-5274ad1f3a4d">
<br>
The following shows the actual rate limitations for the matrix of zoom plan vs weight of requests.  
<img width="512" alt="Screenshot 2023-09-06 at 4 28 19 PM" src="https://github.com/hackclub/slash-z/assets/43505167/7a9f3d6d-a730-4eb0-baf3-9f75b995d7ae">
<br>
Based on this, I believe we are on a "Pro" zoom plan, and thus being rate limited to the tune of **30k requests/day** and separately **10 requests/sec**.
<br>
Assuming the worst-case scenario where we have 20 hosts all being utilized, the original 15 second timer would result in:
<h2>20 hosts * 4 15-sec chunks/m * 60m/h * 24 h/d = 86400 calls/day</h2>
With these new changes:
<h2>20 hosts * 30 2-min chunks/h * 24h/d = 14400 calls/day</h2>
