### PR TITLE
Make timer for reporting stats not ddos zoom apis

### DIFF
--- a/server.js
+++ b/server.js
@@ -59,4 +59,4 @@ setInterval(async () => {
   metrics.gauge("hosts.open", open)
   metrics.gauge("hosts.total", total)
   metrics.gauge("app.active_users", active_users);
-}, 1000);
+}, 1000 * 60);


### PR DESCRIPTION
Previously we would report global stats every 1 second - which itself is fine, but not when calculating stats causes X calls to the zoom stats API, where X = # of current calls.

This is the actual reason for us getting rate limited.