### PR TITLE
store host key

### DIFF
--- a/api/open-zoom-meeting.js
+++ b/api/open-zoom-meeting.js
@@ -126,7 +126,7 @@ export default async ({ creatorSlackID, isHackNight } = {}) => {
   });
 
   // update the host record with the new key
-  if (keyResponse.http_code !== 400) {
+  if (keyResponse.http_code === 200) {
     await Prisma.patch("host", host.id, {
       hostKey: hostKey
     });

--- a/api/open-zoom-meeting.js
+++ b/api/open-zoom-meeting.js
@@ -130,7 +130,19 @@ export default async ({ creatorSlackID, isHackNight } = {}) => {
     await Prisma.patch("host", host.id, {
       hostKey: hostKey
     });
-  } else hostKey = host.hostKey;
+  } else {
+    const hosts = await Prisma.get("host", {
+      where: {
+        email: host.email
+      }
+    });
+    // we know there are just two hosts with the same email
+    // so we grab what's left
+    const otherHost = hosts.filter(h => h.id != host.id)[0];
+
+    // re-assign the host key to the existing one
+    hostKey = otherHost.hostKey;
+  }
 
   // start a meeting with the zoom client
   const meeting = await zoom.post({

--- a/api/open-zoom-meeting.js
+++ b/api/open-zoom-meeting.js
@@ -126,11 +126,9 @@ export default async ({ creatorSlackID, isHackNight } = {}) => {
   });
 
   // update the host record with the new key
-  if (keyResponse !== 400) {
+  if (keyResponse.http_code !== 400) {
     await Prisma.patch("host", host.id, {
-      data: {
-        hostKey: hostKey
-      }
+      hostKey: hostKey
     });
   } else hostKey = host.hostKey;
 

--- a/api/open-zoom-meeting.js
+++ b/api/open-zoom-meeting.js
@@ -43,7 +43,7 @@ export default async ({ creatorSlackID, isHackNight } = {}) => {
   // find an open host w/ less then 2 open meetings. why 2? Zoom lets us host up to 2 concurrent meetings
   // https://support.zoom.us/hc/en-us/articles/206122046-Can-I-Host-Concurrent-Meetings-
   // ¯\_(ツ)_/¯
-  let host = await availableHojwtt();
+  let host = await availableHost();
 
   // no free hosts? let's try closing some stale zoom calls
   if (!host) {

--- a/api/open-zoom-meeting.js
+++ b/api/open-zoom-meeting.js
@@ -126,7 +126,7 @@ export default async ({ creatorSlackID, isHackNight } = {}) => {
   });
 
   // update the host record with the new key
-  if (keyResponse.http_code === 200) {
+  if (keyResponse.http_code === 204) {
     await Prisma.patch("host", host.id, {
       hostKey: hostKey
     });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model Host {
   apiKey      String
   apiSecret   String
   zoomID      String     
-  hostKey     String
+  hostKey     String?
   meetings    Meeting[]
   errors      String[]
   ErrorLog    ErrorLog[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Host {
   apiKey      String
   apiSecret   String
   zoomID      String     
+  hostKey     String
   meetings    Meeting[]
   errors      String[]
   ErrorLog    ErrorLog[]


### PR DESCRIPTION
should resolve #173 

we will now store the host key with associated host in the database
when creating a new meeting, if that host is currently holding a meeting, we grab the existing host key otherwise we create a new one and store that in the db

For this to work, we need to run ´npx prisma db push´ on the production database 