### PR TITLE
update slack call status when meeting ends

### DIFF
--- a/api/close-zoom-call.js
+++ b/api/close-zoom-call.js
@@ -53,7 +53,7 @@ export default async (zoomID, forceClose = false) => {
   
   // 400/404's denote meetings that do not exist.  We need to clean them up on our side.
   // they also denote meetings where all participants have left
-  if (!forceClose (zoomMetrics.http_code == 400 || zoomMetrics.http_code == 404)) {
+  if (!forceClose && (zoomMetrics.http_code == 400 || zoomMetrics.http_code == 404)) {
     
     await Prisma.create('customLogs', { text: `metrics_meeting_doesnt_exist`, zoomCallId: meeting.zoomID })
     await Prisma.patch("meeting", meeting.id, { endedAt: new Date(Date.now()) })

--- a/api/close-zoom-call.js
+++ b/api/close-zoom-call.js
@@ -53,7 +53,7 @@ export default async (zoomID, forceClose = false) => {
   
   // 400/404's denote meetings that do not exist.  We need to clean them up on our side.
   // they also denote meetings where all participants have left
-  if (zoomMetrics.http_code == 400 || zoomMetrics.http_code == 404) {
+  if (!forceClose (zoomMetrics.http_code == 400 || zoomMetrics.http_code == 404)) {
     
     await Prisma.create('customLogs', { text: `metrics_meeting_doesnt_exist`, zoomCallId: meeting.zoomID })
     await Prisma.patch("meeting", meeting.id, { endedAt: new Date(Date.now()) })


### PR DESCRIPTION
previously slash-z it would not mark the slack call as ended because it will return prematurely when it gets a 400/404 event... even if we get a meeting.ended event from zoom

this change ensures that if we get a meeting.ended event, it will mark the slack call as closed