### PR TITLE
upgrade prisma version && create a many-to-one relation between `SchedulingLink` and `AuthedAccount`. 

### DIFF
--- a/api/endpoints/new-schedule-link.js
+++ b/api/endpoints/new-schedule-link.js
@@ -32,7 +32,7 @@ export default async (req, res) => {
   res.json({id,
     videoUri: `https://hack.af/z-join?id=${id}`,
     moreUri: `https://hack.af/z-phone?id=${id}`,
-    stagingVideoUri: !isProd ? `https://6e89-102-244-42-15.ngrok-free.app/api/endpoints/schedule-link?id=${id}` : null 
+    stagingVideoUri: !isProd ? `https://slash-z-staging-1ae8b1c9e24a.herokuapp.com/api/endpoints/schedule-link?id=${id}` : null 
   })
 
   Prisma.create('schedulingLink', {

--- a/api/endpoints/new-schedule-link.js
+++ b/api/endpoints/new-schedule-link.js
@@ -32,7 +32,7 @@ export default async (req, res) => {
   res.json({id,
     videoUri: `https://hack.af/z-join?id=${id}`,
     moreUri: `https://hack.af/z-phone?id=${id}`,
-    stagingVideoUri: !isProd ? `https://slash-z-staging-1ae8b1c9e24a.herokuapp.com/api/endpoints/schedule-link?id=${id}` : null 
+    stagingVideoUri: !isProd ? `https://6e89-102-244-42-15.ngrok-free.app/api/endpoints/schedule-link?id=${id}` : null 
   })
 
   Prisma.create('schedulingLink', {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@bugsnag/js": "^7.11.0",
     "@bugsnag/plugin-express": "^7.11.0",
-    "@prisma/client": "3.3.0",
+    "@prisma/client": "^5.9.1",
     "airtable-plus": "^1.0.4",
     "bottleneck": "^2.19.5",
     "dotenv": "^8.2.0",
@@ -26,7 +26,7 @@
     "node-fetch": "^2.6.1",
     "node-statsd": "^0.1.1",
     "nodemon": "^2.0.7",
-    "prisma": "3.3.0",
+    "prisma": "^5.9.1",
     "response-time": "^2.3.2",
     "zoomus": "^0.1.4"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,8 +63,9 @@ model SchedulingLink {
   meetings        Meeting[]
   meetingsIds     String[]
   creatorSlackID  String?
-  authedAccount   AuthedAccount[] @relation(fields: [authedAccountID], references: [id])
-  authedAccountID String?
+  // authedAccount   AuthedAccount[] @relation(fields: [authedAccountID], references: [id])
+  authedAccount  AuthedAccount @relation(fields: [authedAccountID], references: [id])
+  authedAccountID String
 }
 
 // Previously "Error" in the airtable version
@@ -83,7 +84,7 @@ model ErrorLog {
 model AuthedAccount {
   id              String           @id @default(cuid())
   name            String?
-  schedulingLinks SchedulingLink[]
+  schedulingLinks SchedulingLink[] 
   slackID         String?
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,7 +63,6 @@ model SchedulingLink {
   meetings        Meeting[]
   meetingsIds     String[]
   creatorSlackID  String?
-  // authedAccount   AuthedAccount[] @relation(fields: [authedAccountID], references: [id])
   authedAccount  AuthedAccount @relation(fields: [authedAccountID], references: [id])
   authedAccountID String
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,22 +596,46 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@prisma/client@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.3.0.tgz#7945101206af1927d925a8d9c62bb188e9260c97"
-  integrity sha512-34tonDW2v74VcG1mx+k/IUGG/eSHKwDiYKfFIZgaPLq/C0h8YQxh7pro272xpOf1pt6duX1Bi90dpGijh1MYgQ==
+"@prisma/client@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.9.1.tgz#d92bd2f7f006e0316cb4fda9d73f235965cf2c64"
+  integrity sha512-caSOnG4kxcSkhqC/2ShV7rEoWwd3XrftokxJqOCMVvia4NYV/TPtJlS9C2os3Igxw/Qyxumj9GBQzcStzECvtQ==
+
+"@prisma/debug@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.9.1.tgz#906274e73d3267f88b69459199fa3c51cd9511a3"
+  integrity sha512-yAHFSFCg8KVoL0oRUno3m60GAjsUKYUDkQ+9BA2X2JfVR3kRVSJFc/GpQ2fSORi4pSHZR9orfM4UC9OVXIFFTA==
+
+"@prisma/engines-version@5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64":
+  version "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64.tgz#54d2164f28d23e09d41cf9eb0bddbbe7f3aaa660"
+  integrity sha512-HFl7275yF0FWbdcNvcSRbbu9JCBSLMcurYwvWc8WGDnpu7APxQo2ONtZrUggU3WxLxUJ2uBX+0GOFIcJeVeOOQ==
+
+"@prisma/engines@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.9.1.tgz#767539afc6f193a182d0495b30b027f61f279073"
+  integrity sha512-gkdXmjxQ5jktxWNdDA5aZZ6R8rH74JkoKq6LD5mACSvxd2vbqWeWIOV0Py5wFC8vofOYShbt6XUeCIUmrOzOnQ==
   dependencies:
-    "@prisma/engines-version" "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+    "@prisma/debug" "5.9.1"
+    "@prisma/engines-version" "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
+    "@prisma/fetch-engine" "5.9.1"
+    "@prisma/get-platform" "5.9.1"
 
-"@prisma/engines-version@3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c.tgz#10269530152dc126c81b363c27cefc3c060013e2"
-  integrity sha512-g21xPYq0zHoJ/xUkNxIf5Hle0oiDyelZHU8gwq7J3RNVrccjbUZ28S99KT4yUabV8SQQRNSnR0QMLGMv9Eqs/A==
+"@prisma/fetch-engine@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.9.1.tgz#5d3b2c9af54a242e37b3f9561b59ab72f8e92818"
+  integrity sha512-l0goQOMcNVOJs1kAcwqpKq3ylvkD9F04Ioe1oJoCqmz05mw22bNAKKGWuDd3zTUoUZr97va0c/UfLNru+PDmNA==
+  dependencies:
+    "@prisma/debug" "5.9.1"
+    "@prisma/engines-version" "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
+    "@prisma/get-platform" "5.9.1"
 
-"@prisma/engines@3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c.tgz#99026c466ffe1229c94e3392a1ae923a149be4f1"
-  integrity sha512-T3nEnRWmoneNZJPd9IBR29G8ZDUjNelA8+cG5y8/lh6vySm6ryWSNxj1s377U9YzFYyZmXiA9vK1iyxMoRff/g==
+"@prisma/get-platform@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.9.1.tgz#a66bb46ab4d30db786c84150ef074ab0aad4549e"
+  integrity sha512-6OQsNxTyhvG+T2Ksr8FPFpuPeL4r9u0JF0OZHUBI/Uy9SS43sPyAIutt4ZEAyqWQt104ERh70EZedkHZKsnNbg==
+  dependencies:
+    "@prisma/debug" "5.9.1"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -3003,12 +3027,12 @@ pretty-format@^29.6.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prisma@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.3.0.tgz#9fd685111c26d078dd7eb6ffaddc584a33ec42b4"
-  integrity sha512-E7C9mXRwZVpcnSeJT533qGHUVrYULsE9ihFvAtQMuxhTXkxoRlMLyo/1ZOyeu9GdXP8DJ7ruLOw06kEs/N3dVg==
+prisma@^5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.9.1.tgz#baa3dd635fbf71504980978f10f55ea11068f6aa"
+  integrity sha512-Hy/8KJZz0ELtkw4FnG9MS9rNWlXcJhf98Z2QMqi0QiVMoS8PzsBkpla0/Y5hTlob8F3HeECYphBjqmBxrluUrQ==
   dependencies:
-    "@prisma/engines" "3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+    "@prisma/engines" "5.9.1"
 
 process@~0.5.1:
   version "0.5.2"


### PR DESCRIPTION
- create a many to one relation between `SchedulingLink` and `AuthedAccount`. 
- upgrade prisma to latest

I do not find a clear need for the there to be a many-to-many relation between an AuthedAccount and a SchedulingLink given that a schedulingLink is created and by a single person. 

## Applying the changes
- [ ] run `npx prisma db push` to update the db schema