### PR TITLE
Add callback_uri support to OAuth flow

### DIFF
--- a/api/endpoints/new-schedule-link.js
+++ b/api/endpoints/new-schedule-link.js
@@ -14,6 +14,13 @@ export default async (req, res) => {
     const redirectUrl = isProd ? 'https://hack.club/z/slack-auth' : "https://slash-z-staging-1ae8b1c9e24a.herokuapp.com/api/endpoints/slack-auth"
     
     const state = { userID: user.id }
+
+    // If the caller passed a callback_uri, include it in the OAuth state
+    // so slack-auth.js can redirect there after linking the Slack identity.
+    if (req.query.callback_uri) {
+      state.callbackUri = req.query.callback_uri
+    }
+
     console.log({state})
     const stateString = encodeURIComponent(Buffer.from(JSON.stringify(state), "utf8").toString("base64"))
     

--- a/api/endpoints/slack-auth.js
+++ b/api/endpoints/slack-auth.js
@@ -8,7 +8,7 @@ export default async (req, res) => {
 
   console.log({code, recordIDData})
   
-  const {userID, meetingID} = JSON.parse(Buffer.from(decodeURIComponent(recordIDData), "base64").toString())
+  const {userID, meetingID, callbackUri} = JSON.parse(Buffer.from(decodeURIComponent(recordIDData), "base64").toString())
 
   console.log({code, recordIDData, userID, meetingID})
 
@@ -43,8 +43,14 @@ export default async (req, res) => {
   if (user) {
     const slackData = await fetch(tokenUrl, {method: 'post'}).then(r => r.json())
     await Prisma.patch('authedAccount', userID, { slackID: slackData['authed_user']['id'] })
-    // res.status(200).send('It worked! You can close this tab now')
-    res.redirect('/auth-success.html')
+
+    // If a callback URI was provided (e.g. from a cal.com integration),
+    // redirect there instead of the default success page.
+    if (callbackUri) {
+      res.redirect(callbackUri)
+    } else {
+      res.redirect('/auth-success.html')
+    }
   } else {
     // oh, we're far off the yellow brick road now...
     // res.status(422).send('Uh oh...')


### PR DESCRIPTION
## Summary

- Adds optional `callback_uri` query param to `new-schedule-link` endpoint
- Passes it through the Slack OAuth state so `slack-auth.js` can redirect there after linking
- Enables external integrations (e.g. a cal.com conferencing app) to complete their own setup flow after the user authenticates with Slack

## Changes

- **`api/endpoints/new-schedule-link.js`** — reads `req.query.callback_uri` and includes it in the OAuth state object
- **`api/endpoints/slack-auth.js`** — destructures `callbackUri` from state, redirects there if present, otherwise falls back to `/auth-success.html`

Fully backwards-compatible — no behavior change when `callback_uri` is omitted.

## Test plan

- [ ] Install the app without `callback_uri` — should redirect to `/auth-success.html` as before
- [ ] Call `new-schedule-link?id=test&callback_uri=https://example.com/callback` — after Slack OAuth, should redirect to `https://example.com/callback`
- [ ] Existing Google Workspace add-on flow still works (no `callback_uri` passed)